### PR TITLE
chore(auth): extend host cookie lifespan

### DIFF
--- a/app/routes/auth/index.ts
+++ b/app/routes/auth/index.ts
@@ -227,6 +227,7 @@ const host = {
 	httpOnly: true,
 	secure: true,
 	sameSite: "none",
+	maxAge: toSeconds(7, "day"),
 } as CookieOptions;
 
 auth.onError(async (error, c) => {


### PR DESCRIPTION
- Added `maxAge` of 7 days to host cookie configuration for persistent sessions.